### PR TITLE
make the attr. optional

### DIFF
--- a/docs-src/documentation/conditional-attributes.page.ts
+++ b/docs-src/documentation/conditional-attributes.page.ts
@@ -18,125 +18,133 @@ export default ({
         prevPage,
         docsMenu,
         content: html`
-        ${Heading(page.name)}
-        <p>
-            You cannot use template literal value to define attributes directly on the
-            tag.
-        </p>
-        ${CodeSnippet(
-            'const disabledAttr = "disabled=\'\'";\n\n' +
-                '// will not render the disabled attribute\n' +
-                'html`<button ${disabledAttr}>click me</button>`;\n' +
-                '// renders <button>click me</button>',
-            'typescript'
-        )}
-        <p>
-            This means that you need another way to dynamically render
-            attributes and that way is the Markup <code>attr</code> attribute's name prefixer.
-        </p>
-        ${CodeSnippet(
-            'const disabled = true;\n' +
-                '\n' +
-                'html`<button attr.disabled="${disabled}">click me</button>`;',
-            'typescript'
-        )}
-        <p>
-            In the above example the <code>disabled</code> attribute
-            was prefixed with <code>attr.</code> then provided the condition(boolean) as
-            value to whether include that attribute.
-        </p>
-        ${Heading('Boolean attributes', 'h3')}
-        <p>
-            <a
-                href="https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML"
-                >Boolean attributes</a
-            >
-            are attributes that affect the element by
-            simply being on the tag or whether they have value of
-            <code>true</code> or <code>false</code>. HTML natively have these.
-        </p>
-        <p>
-            The boolean attribute pattern is simple:
-            <code>attr.NAME="CONDITION"</code>
-        </p>
-        ${CodeSnippet(
-            'html`<input type="checkbox" attr.checked="true"/>`;',
-            'typescript'
-        )}
-        <p>
-            You may directly set the value as <code>true</code> or
-            <code>false</code> string values or add a variable.
-        </p>
-        ${CodeSnippet(
-            'const checked = false;\n\n' +
-                'html`<input type="checkbox" attr.checked="${checked}"/>`;',
-            'typescript'
-        )}
-        <p>The <code>attr</code> prefix understands this and will only add these attributes when the value is <code>truthy</code>.</p>
-        ${Heading('The class attribute', 'h3')}
-        <p>
-            The class attribute has a special handle that allows you to
-            dynamically set classes more elegantly.
-        </p>
-        <p>
-                The class attribute pattern can be a key-value type
-                <code>attr.class="CLASS_STRING | CONDITION"</code> or a specific class <code>attr.class.NAME="CONDITION"</code
-        </p>
-        ${CodeSnippet(
-            'html`<button attr.class="disabled btn | true">click me</button>`;\n' +
-                '// renders: <button class="disabled btn">click me</button>\n\n' +
-                'const primary = true;\n' +
-                'html`<button class="btn" attr.class.primary="${primary}">click me</button>\n`;' +
-                '// renders: <button class="primary btn">click me</button>\n',
-            'typescript'
-        )}
-        <div class="info">You need to use the <code>|</code> (pipe symbol) to separate the value from the condition.</div>
-        ${Heading('The style attribute', 'h3')}
-        <p>
-            The style attribute also have a special handling that allows you to
-            target specific CSS properties and set their values dynamically.
-        </p>
-        <p>
-                The style attribute pattern can be a key-value type
-                <code>attr.style="CSS_STRING | CONDITION"</code> or a specific style property <code>attr.style.CSS_PROPERTY="CSS_VALUE | CONDITION"</code
-        </p>
-        ${CodeSnippet(
-            'html`<button attr.style="opacity: 0.5; | true">click me</button>`;\n' +
-                '// renders: <button style="opacity: 0.5;">click me</button>\n\n' +
-                'const primary = true;\n' +
-                'html`<button attr.style.color="orange | ${primary}">click me</button>\n`;' +
-                '// renders: <button style="color: orange">click me</button>\n',
-            'typescript'
-        )}
-        ${Heading('The data attribute', 'h3')}
-        <p>
-            The data attribute is a special attribute in HTML and the
-            <code>attr</code> simplifies it further.
-        </p>
-        <p>Data attributes follow the pattern: <code>attr-data-NAME="VALUE | CONDITION"</code> and
-           can also be <code>attr-data-NAME="CONDITION"</code>  if value is same as the condition value.
-           The template will evaluate if the value is truthy or falsy to decide
-           whether the attribute should be set.</p>
-        ${CodeSnippet(
-            'const loading = true;\n\n' +
-                'html`<button attr.data.loading="${loading}" attr.data.btn="true">click me</button>`',
-            'typescript'
-        )}
-        ${Heading('Other attributes', 'h3')}
-        <p>
-            Everything else will fall into the category of a key-value attribute
-            which is a collection of attributes that require specific values or
-            work as "prop" for a tag to pass data or set configurations.
-        </p>
-        <p>All other attributes follow the pattern: <code>attr-NAME="VALUE | CONDITION"</code> or
-            <code>attr-NAME="CONDITION"</code> if value is same as the condition value.
-           The template will evaluate if the value is truthy or falsy to decide
-           whether the attribute should be set.</p>
-        ${CodeSnippet(
-            'const label = "action button";\n\n' +
-                '// will not render if label is an empty string\n' +
-                'html`<button attr.aria-label="${label}">click me</button>`',
-            'typescript'
-        )}
-    `,
+	        ${Heading(page.name)}
+	        <p>
+		        You cannot use template literal value to define attributes directly on the
+		        tag.
+	        </p>
+	        ${CodeSnippet(
+                'const disabledAttr = "disabled=\'\'";\n\n' +
+                    '// will not render the disabled attribute\n' +
+                    'html`<button ${disabledAttr}>click me</button>`;\n' +
+                    '// renders <button>click me</button>',
+                'typescript'
+            )}
+	        <p>
+		        This means that you need another way to dynamically render
+		        attributes and that way is the Markup <code>attr</code> attribute's name prefixer.
+	        </p>
+	        ${CodeSnippet(
+                'const disabled = true;\n' +
+                    '\n' +
+                    'html`<button attr.disabled="${disabled}">click me</button>`;',
+                'typescript'
+            )}
+	        <p>
+		        In the above example the <code>disabled</code> attribute
+		        was prefixed with <code>attr.</code> then provided the condition(boolean) as
+		        value to whether include that attribute.
+	        </p>
+	        <div class="info">
+		        The <code>attr.</code> is not always needed. Attributes like <code>class</code>, <code>style</code>, <code>data</code>,
+		        and <a href="https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML" target="_blank">HTML boolean
+		                                                                                                     attributes</a>
+		        work without it or can have the condition specified after the pipe <code>|</code> as the value. Everything
+		        else requires it.
+	        </div>
+	        ${Heading('Boolean attributes', 'h3')}
+	        <p>
+		        <a
+			        href="https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML"
+		        >Boolean attributes</a
+		        >
+		        are attributes that affect the element by
+		        simply being on the tag or whether they have value of
+		        <code>true</code> or <code>false</code>. HTML natively have these.
+	        </p>
+	        <p>
+		        The boolean attribute pattern is simple: <code>NAME="CONDITION"</code>. The <code>attr.</code> prefix is NOT
+		        required.
+	        </p>
+	        ${CodeSnippet(
+                'html`<input type="checkbox" checked="true"/>`;',
+                'typescript'
+            )}
+	        <p>
+		        You may directly set the value as <code>true</code> or
+		        <code>false</code> string values or add a variable.
+	        </p>
+	        ${CodeSnippet(
+                'const checked = false;\n\n' +
+                    'html`<input type="checkbox" checked="${checked}"/>`;',
+                'typescript'
+            )}
+	        ${Heading('The class attribute', 'h3')}
+	        <p>
+		        The class attribute has a special handle that allows you to
+		        dynamically set specific classes more elegantly.
+	        </p>
+	        <p>
+		        The class attribute pattern can be a key-value type
+		        <code>class="CLASS_STRING | CONDITION"</code> or a specific class
+		        <code>class.NAME="CONDITION"</code>.
+	        </p>
+	        ${CodeSnippet(
+                'html`<button class="disabled btn | true">click me</button>`;\n' +
+                    '// renders: <button class="disabled btn">click me</button>\n\n' +
+                    'const primary = true;\n' +
+                    'html`<button class="btn" class.primary="${primary}">click me</button>\n`;' +
+                    '// renders: <button class="primary btn">click me</button>\n',
+                'typescript'
+            )}
+	        <div class="info">You need to use the <code>|</code> (pipe symbol) to separate the value from the condition
+	                          and the <code>attr.</code> prefix is not required.
+	        </div>
+	        ${Heading('The style attribute', 'h3')}
+	        <p>
+		        The style attribute also have a special handling that allows you to
+		        target specific CSS properties and set their values dynamically.
+	        </p>
+	        <p>
+		        The style attribute pattern can be a key-value type
+		        <code>style="CSS_STRING | CONDITION"</code> or a specific style property <code>style.CSS_PROPERTY="CSS_VALUE
+		                                                                                       | CONDITION"</code
+	        </p>
+	        ${CodeSnippet(
+                'html`<button style="opacity: 0.5; | true">click me</button>`;\n' +
+                    '// renders: <button style="opacity: 0.5;">click me</button>\n\n' +
+                    'const primary = true;\n' +
+                    'html`<button style.color="orange | ${primary}">click me</button>\n`;' +
+                    '// renders: <button style="color: orange">click me</button>\n',
+                'typescript'
+            )}
+	        <p>The <code>attr.</code> prefix is not required for style attributes.</p>
+	        ${Heading('The data attribute', 'h3')}
+	        <p>Data attributes follow the pattern: <code>data.NAME="VALUE | CONDITION"</code> and
+	           can also be <code>data.NAME="CONDITION"</code> if value is same as the condition value.
+	           The template will evaluate if the value is truthy or falsy to decide
+	           whether the attribute should be set.</p>
+	        ${CodeSnippet(
+                'const loading = true;\n\n' +
+                    'html`<button data.loading="${loading}" data.btn="true">click me</button>`',
+                'typescript'
+            )}
+	        <p>The <code>attr.</code> prefix is not required for data attributes.</p>
+	        ${Heading('Other attributes', 'h3')}
+	        <p>
+		        Everything else will fall into the category of a key-value pairs
+		        which is a collection of attributes that require specific values or
+		        work as "prop" for a tag to pass data or set configurations.
+	        </p>
+	        <p>All other attributes follow the pattern: <code>attr.NAME="VALUE | CONDITION"</code> or
+		        <code>attr.NAME="CONDITION"</code> if value is same as the condition value.
+	           The template will evaluate if the value is truthy or falsy to decide
+	           whether the attribute should be set.</p>
+	        ${CodeSnippet(
+                'const label = "action button";\n\n' +
+                    '// will not render if label is an empty string\n' +
+                    'html`<button attr.aria-label="${label}">click me</button>`',
+                'typescript'
+            )}
+        `,
     })

--- a/docs-src/documentation/conditional-attributes.page.ts
+++ b/docs-src/documentation/conditional-attributes.page.ts
@@ -37,7 +37,7 @@ export default ({
 	        ${CodeSnippet(
                 'const disabled = true;\n' +
                     '\n' +
-                    'html`<button attr.disabled="${disabled}">click me</button>`;',
+                    'html`<button disabled="${disabled}">click me</button>`;',
                 'typescript'
             )}
 	        <p>

--- a/docs-src/documentation/effect-helper.page.ts
+++ b/docs-src/documentation/effect-helper.page.ts
@@ -67,17 +67,17 @@ export default ({
                     '  <h1>Tab Example</h1>\n' +
                     '  <ul>\n' +
                     '    <li \n' +
-                    '      attr.class.active="${is(activeTab, \'home\')}" \n' +
+                    '      class.active="${is(activeTab, \'home\')}" \n' +
                     '      onclick="${() => setActiveTab(\'home\')}">\n' +
                     '      Home\n' +
                     '    </li>\n' +
                     '    <li \n' +
-                    '      attr.class.active="${is(activeTab, \'about\')}"\n' +
+                    '      class.active="${is(activeTab, \'about\')}"\n' +
                     '      onclick="${() => setActiveTab(\'about\')}">\n' +
                     '      About\n' +
                     '    </li>\n' +
                     '    <li \n' +
-                    '      attr.class.active="${is(activeTab, \'contact\')}"\n' +
+                    '      class.active="${is(activeTab, \'contact\')}"\n' +
                     '      onclick="${() => setActiveTab(\'contact\')}">\n' +
                     '      Contact\n' +
                     '    </li>\n' +

--- a/docs-src/documentation/function-components.page.ts
+++ b/docs-src/documentation/function-components.page.ts
@@ -42,7 +42,7 @@ export default ({
                     '  return html`\n' +
                     '    <button \n' +
                     '      type="${type}"\n' +
-                    '      attr.disabled="${disabled}"\n' +
+                    '      disabled="${disabled}"\n' +
                     '      >\n' +
                     '      ${content}\n' +
                     '    </button>`;\n' +

--- a/docs-src/documentation/is-isnot-helpers.page.ts
+++ b/docs-src/documentation/is-isnot-helpers.page.ts
@@ -55,7 +55,7 @@ export default ({
                 attribute values and even body content.
             </p>
             ${CodeSnippet(
-                'html`<button attr.disabled="${is(status, \'logged\')}">login</button>`',
+                'html`<button disabled="${is(status, \'logged\')}">login</button>`',
                 'typescript'
             )}
             <p>

--- a/docs-src/documentation/web-components.page.ts
+++ b/docs-src/documentation/web-components.page.ts
@@ -85,7 +85,7 @@ export default ({
                     '    <input \n' +
                     '      type="text" \n' +
                     '      value="${() => this.value}"\n' +
-                    '      attr.disabled="${() => this.disabled}"\n' +
+                    '      disabled="${() => this.disabled}"\n' +
                     '      />\n' +
                     '  `\n' +
                     '  \n' +

--- a/docs-src/index.page.ts
+++ b/docs-src/index.page.ts
@@ -80,7 +80,7 @@ export default ({ page, name }: PageComponentProps) =>
                 ${CodeSnippet('yarn add @beforesemicolon/markup', 'typescript')}
                 <p>
                     Or simply add the following script in the head of your
-                    document
+                    document.
                 </p>
                 ${CodeSnippet(
                     '<script src="https://unpkg.com/@beforesemicolon/markup/dist/client.js"/>',
@@ -93,7 +93,7 @@ export default ({ page, name }: PageComponentProps) =>
                 <p>
                     The templating system will handle all the rendering needs of
                     your project. With that out of the way, what you can build
-                    is really up to you. It can be a full web application, a UI
+                    is up to you. It can be a full web application, a UI
                     components library or the next UI framework. The only limit
                     is your imagination.
                 </p>

--- a/docs-src/partials/doc-page-layout.ts
+++ b/docs-src/partials/doc-page-layout.ts
@@ -44,7 +44,7 @@ export const DocPageLayout = ({
                                         ${g.list.map(
                                             (l) => html`
                                                 <li
-                                                    attr.class.active="${l.path ===
+                                                    class.active="${l.path ===
                                                     page.path}"
                                                 >
                                                     <a href="..${l.path}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@beforesemicolon/markup",
-    "version": "0.11.0",
+    "version": "0.12.0",
     "description": "Reactive HTML Templating System",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/executable/handle-attr-directive-executable.spec.ts
+++ b/src/executable/handle-attr-directive-executable.spec.ts
@@ -10,20 +10,20 @@ describe('handleAttrDirectiveExecutable', () => {
 
     it('should handle style attribute', () => {
         const e1: ExecutableValue = {
-            name: 'attr',
+            name: 'style',
             rawValue: 'bold',
             value: '',
             renderedNodes: [div],
-            prop: 'style.font-style',
+            prop: 'font-style',
             parts: [],
         }
 
         const e2: ExecutableValue = {
-            name: 'attr',
+            name: 'style',
             rawValue: 'background-color: #900 | true',
             value: '',
             renderedNodes: [div],
-            prop: 'style',
+            prop: '',
             parts: [],
         }
 
@@ -51,20 +51,20 @@ describe('handleAttrDirectiveExecutable', () => {
 
     it('should handle class attribute', () => {
         const e1: ExecutableValue = {
-            name: 'attr',
+            name: 'class',
             rawValue: 'false',
             value: '',
             renderedNodes: [div],
-            prop: 'class.simple-cls',
+            prop: 'simple-cls',
             parts: [],
         }
 
         const e2: ExecutableValue = {
-            name: 'attr',
+            name: 'class',
             rawValue: 'sample | true',
             value: '',
             renderedNodes: [div],
-            prop: 'class',
+            prop: '',
             parts: [],
         }
 
@@ -90,20 +90,20 @@ describe('handleAttrDirectiveExecutable', () => {
 
     it('should handle data attribute', () => {
         const e1: ExecutableValue = {
-            name: 'attr',
+            name: 'data',
             rawValue: 'val | true',
             value: '',
             renderedNodes: [div],
-            prop: 'data.simple-val',
+            prop: 'simple-val',
             parts: [],
         }
 
         const e2: ExecutableValue = {
-            name: 'attr',
+            name: 'data',
             rawValue: 'simple-val | true',
             value: '',
             renderedNodes: [div],
-            prop: 'data',
+            prop: '',
             parts: [],
         }
 
@@ -123,20 +123,20 @@ describe('handleAttrDirectiveExecutable', () => {
 
     it('should handle boolean attribute', () => {
         const e1: ExecutableValue = {
-            name: 'attr',
+            name: 'disabled',
             rawValue: 'true',
             value: '',
             renderedNodes: [div],
-            prop: 'disabled',
+            prop: '',
             parts: [],
         }
 
         const e2: ExecutableValue = {
-            name: 'attr',
+            name: 'hidden',
             rawValue: 'until-found | true',
             value: '',
             renderedNodes: [div],
-            prop: 'hidden',
+            prop: '',
             parts: [],
         }
 
@@ -158,20 +158,20 @@ describe('handleAttrDirectiveExecutable', () => {
 
     it('should handle all other attributes', () => {
         const e1: ExecutableValue = {
-            name: 'attr',
+            name: 'id',
             rawValue: 'sample | true',
             value: '',
             renderedNodes: [div],
-            prop: 'id',
+            prop: '',
             parts: [],
         }
 
         const e2: ExecutableValue = {
-            name: 'attr',
+            name: 'aria-disabled',
             rawValue: 'true',
             value: '',
             renderedNodes: [div],
-            prop: 'aria-disabled',
+            prop: '',
             parts: [],
         }
 

--- a/src/executable/handle-attr-directive-executable.ts
+++ b/src/executable/handle-attr-directive-executable.ts
@@ -11,8 +11,8 @@ export const handleAttrDirectiveExecutable = (
     rawValue: string
 ) => {
     if (rawValue !== executableValue.value) {
+        const { name: attrName, prop: property } = executableValue
         executableValue.value = rawValue
-        const [attrName, property] = (executableValue.prop || '').split('.')
         const element = executableValue.renderedNodes[0] as HTMLElement
         // eslint-disable-next-line prefer-const
         let [value, condition] = rawValue.split(/\|/).map((s) => s.trim())

--- a/src/executable/handle-executable.spec.ts
+++ b/src/executable/handle-executable.spec.ts
@@ -109,11 +109,11 @@ describe('handleExecutable', () => {
             ...defaultExec,
             directives: [
                 {
-                    name: 'attr',
+                    name: 'disabled',
                     rawValue: 'true',
                     value: '',
                     renderedNodes: [div],
-                    prop: 'disabled',
+                    prop: '',
                     parts: [true],
                 },
             ],
@@ -125,8 +125,8 @@ describe('handleExecutable', () => {
             ...defaultExec,
             directives: [
                 {
-                    name: 'attr',
-                    prop: 'disabled',
+                    name: 'disabled',
+                    prop: '',
                     rawValue: 'true',
                     renderedNodes: [div],
                     value: "true",

--- a/src/html.spec.ts
+++ b/src/html.spec.ts
@@ -545,10 +545,48 @@ describe('html', () => {
 			)
 		})
 		
+		it('class name as property without attr.', () => {
+			let loading = true
+			const btn = html`
+				<button class.loading="${() => loading}" class.btn="true">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe(
+				'<button class="loading btn">click me</button>'
+			)
+			
+			loading = false
+			
+			btn.update()
+			
+			expect(document.body.innerHTML).toBe(
+				'<button class="btn">click me</button>'
+			)
+		})
+		
 		it('class name as value', () => {
 			let loading = true
 			const btn = html`
 				<button attr.class="loading | ${() => loading}">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe(
+				'<button class="loading">click me</button>'
+			)
+			
+			loading = false
+			
+			btn.update()
+			
+			expect(document.body.innerHTML).toBe('<button>click me</button>')
+		})
+		
+		it('class name as value without attr.', () => {
+			let loading = true
+			const btn = html`
+				<button class="loading | ${() => loading}">click me</button>`
 			
 			btn.render(document.body)
 			
@@ -583,6 +621,66 @@ describe('html', () => {
 			)
 		})
 		
+		it('data name as property without attr.', () => {
+			let loading = true
+			const btn = html`
+				<button data.loading="${() => loading}" data.btn="true">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe(
+				'<button data-loading="true" data-btn="true">click me</button>'
+			)
+			
+			loading = false
+			
+			btn.update()
+			
+			expect(document.body.innerHTML).toBe(
+				'<button data-btn="true">click me</button>'
+			)
+		})
+		
+		it('data name as property without dot notation', () => {
+			let loading = true
+			const btn = html`
+				<button attr.data-loading="${() => loading}" attr.data-btn="true">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe(
+				'<button data-loading="true" data-btn="true">click me</button>'
+			)
+			
+			loading = false
+			
+			btn.update()
+			
+			expect(document.body.innerHTML).toBe(
+				'<button data-btn="true">click me</button>'
+			)
+		})
+		
+		it('data name as property without attr. and dot notation', () => {
+			let loading = true
+			const btn = html`
+				<button data-loading="${() => loading}" data-btn="true">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe(
+				'<button data-loading="true" data-btn="true">click me</button>'
+			)
+			
+			loading = false
+			
+			btn.update()
+			
+			expect(document.body.innerHTML).toBe(
+				'<button data-btn="true">click me</button>'
+			)
+		})
+		
 		it('data name as value wont work', () => {
 			const loading = true
 			const btn = html`
@@ -593,9 +691,30 @@ describe('html', () => {
 			expect(document.body.innerHTML).toBe('<button>click me</button>')
 		})
 		
+		it('data name as value wont work without attr.', () => {
+			const loading = true
+			const btn = html`
+				<button data="loading, ${() => loading}">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe('<button>click me</button>')
+		})
+		
 		it('style property without flag', () => {
 			const btn = html`
 				<button attr.style.cursor="pointer">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe(
+				'<button style="cursor: pointer;">click me</button>'
+			)
+		})
+		
+		it('style property without flag without attr.', () => {
+			const btn = html`
+				<button style.cursor="pointer">click me</button>`
 			
 			btn.render(document.body)
 			
@@ -615,10 +734,39 @@ describe('html', () => {
 			)
 		})
 		
+		it('style value without flag without attr.', () => {
+			const btn = html`
+				<button style="cursor: pointer">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe(
+				'<button style="cursor: pointer;">click me</button>'
+			)
+		})
+		
 		it('style property with flag', () => {
 			let pointer = false
 			const btn = html`
 				<button attr.style.cursor="pointer | ${() => pointer}">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe('<button>click me</button>')
+			
+			pointer = true
+			
+			btn.update()
+			
+			expect(document.body.innerHTML).toBe(
+				'<button style="cursor: pointer;">click me</button>'
+			)
+		})
+		
+		it('style property with flag without attr.', () => {
+			let pointer = false
+			const btn = html`
+				<button style.cursor="pointer | ${() => pointer}">click me</button>`
 			
 			btn.render(document.body)
 			
@@ -651,6 +799,24 @@ describe('html', () => {
 			)
 		})
 		
+		it('style value with flag without attr.', () => {
+			let pointer = false
+			const btn = html`
+				<button style="cursor: pointer | ${() => pointer}">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe('<button>click me</button>')
+			
+			pointer = true
+			
+			btn.update()
+			
+			expect(document.body.innerHTML).toBe(
+				'<button style="cursor: pointer;">click me</button>'
+			)
+		})
+		
 		it('any boolean attr', () => {
 			let disabled = true
 			const btn = html`
@@ -669,10 +835,46 @@ describe('html', () => {
 			expect(document.body.innerHTML).toBe('<button>click me</button>')
 		})
 		
+		it('any boolean attr without attr.', () => {
+			let disabled = true
+			const btn = html`
+				<button disabled="${() => disabled}">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe(
+				'<button disabled="">click me</button>'
+			)
+			
+			disabled = false
+			
+			btn.update()
+			
+			expect(document.body.innerHTML).toBe('<button>click me</button>')
+		})
+		
 		it('any boolean attr with possible values', () => {
 			let hidden = true
 			const btn = html`
 				<button attr.hidden="until-found | ${() => hidden}">click me</button>`
+			
+			btn.render(document.body)
+			
+			expect(document.body.innerHTML).toBe(
+				'<button hidden="until-found">click me</button>'
+			)
+			
+			hidden = false
+			
+			btn.update()
+			
+			expect(document.body.innerHTML).toBe('<button>click me</button>')
+		})
+		
+		it('any boolean attr with possible values without attr.', () => {
+			let hidden = true
+			const btn = html`
+				<button hidden="until-found | ${() => hidden}">click me</button>`
 			
 			btn.render(document.body)
 			
@@ -727,6 +929,19 @@ describe('html', () => {
 			const [disabled, setDisabled] = state(false);
 			
 			html`<button attr.disabled="${is(disabled, true)}" attr.class="disabled | ${is(disabled, true)}">click me</button>`.render(document.body)
+			
+			expect(document.body.innerHTML).toBe('<button>click me</button>')
+			
+			setDisabled(true);
+			
+			expect(document.body.innerHTML).toBe('<button disabled="" class="disabled">click me</button>')
+		});
+		
+		it('should work with helper value without attr.', () => {
+			const is = helper(<T>(st: () => T, val: unknown) => st() === val);
+			const [disabled, setDisabled] = state(false);
+			
+			html`<button disabled="${is(disabled, true)}" class="disabled | ${is(disabled, true)}">click me</button>`.render(document.body)
 			
 			expect(document.body.innerHTML).toBe('<button>click me</button>')
 			

--- a/src/utils/suspense.spec.ts
+++ b/src/utils/suspense.spec.ts
@@ -23,7 +23,7 @@ describe('suspense', () => { // @ts-ignore
 		html`${suspense(() => new Promise((res, rej) => {
 			rej(new Error('failed'))
 			setTimeout(() => {
-				expect(document.body.innerHTML).toBe('<p style="color: red">failed</p>')
+				expect(document.body.innerHTML).toBe('<p style="color: red;">failed</p>')
 				done()
 			}, 0)
 		}))}`.render(document.body)
@@ -36,7 +36,7 @@ describe('suspense', () => { // @ts-ignore
 			// @ts-ignore
 			res(null)
 			setTimeout(() => {
-				expect(document.body.innerHTML).toBe('<p style="color: red">async action did not return a HTMLTemplate instance</p>')
+				expect(document.body.innerHTML).toBe('<p style="color: red;">async action did not return a HTMLTemplate instance</p>')
 				done()
 			}, 0)
 		}))}`.render(document.body)


### PR DESCRIPTION
Addresses feature request #6 by making the `attr.` optional for native HTML boolean attributes, class, style, and data.

The `attr.` can still be used for everything el, and this keeps things backward-compatible