### PR TITLE
Add open-source community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ECorreia45

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Report reproducible incorrect behavior
+title: '[Bug]: '
+labels: [bug]
+body:
+    - type: markdown
+      attributes:
+          value: Thanks for taking the time to report a bug. Do not disclose security vulnerabilities here; follow SECURITY.md instead.
+    - type: input
+      id: version
+      attributes:
+          label: Package version
+          placeholder: 1.2.3
+      validations:
+          required: true
+    - type: textarea
+      id: description
+      attributes:
+          label: What happened?
+          description: Describe the actual and expected behavior.
+      validations:
+          required: true
+    - type: textarea
+      id: reproduction
+      attributes:
+          label: Minimal reproduction
+          description: Provide a repository, playground, or concise steps that reproduce the problem.
+      validations:
+          required: true
+    - type: textarea
+      id: environment
+      attributes:
+          label: Environment
+          description: Include browser or runtime, operating system, and other relevant versions.
+      validations:
+          required: true
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Checklist
+          options:
+              - label: I searched existing issues for duplicates.
+                required: true
+              - label: This is not a security vulnerability.
+                required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Security vulnerability
+      url: https://github.com/beforesemicolon/markup/security/advisories/new
+      about: Report a vulnerability privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Propose a focused improvement
+title: '[Feature]: '
+labels: [enhancement]
+body:
+    - type: textarea
+      id: problem
+      attributes:
+          label: Problem
+          description: What problem or limitation would this address?
+      validations:
+          required: true
+    - type: textarea
+      id: proposal
+      attributes:
+          label: Proposed solution
+          description: Describe the API, behavior, or documentation change you propose.
+      validations:
+          required: true
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: Alternatives considered
+          description: What workarounds or alternative designs have you considered?
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Checklist
+          options:
+              - label: I searched existing issues and discussions for similar proposals.
+                required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+Describe what changed and why.
+
+## Related Issue
+
+Link the related issue, if any.
+
+## Verification
+
+-   [ ] Tests pass locally.
+-   [ ] Lint and build checks pass locally.
+-   [ ] Tests were added or updated when behavior changed.
+-   [ ] Documentation was updated when public behavior changed.
+-   [ ] The change does not disclose a security vulnerability publicly.
+-   [ ] I have read and followed `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+-   Demonstrating empathy and kindness toward other people
+-   Respecting differing opinions, viewpoints, and experiences
+-   Giving and gracefully accepting constructive feedback
+-   Accepting responsibility, apologizing to those affected by our mistakes, and
+    learning from the experience
+-   Focusing on what is best for the overall community
+
+Examples of unacceptable behavior include:
+
+-   Sexualized language or imagery, and sexual attention or advances of any kind
+-   Trolling, insulting or derogatory comments, and personal or political attacks
+-   Public or private harassment
+-   Publishing another person's private information without explicit permission
+-   Conduct that could reasonably be considered inappropriate in a professional
+    setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing these standards.
+They may remove, edit, or reject comments, commits, code, issues, and other
+contributions that do not align with this Code of Conduct, and will communicate
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies in all project spaces and when an individual is
+officially representing the project in public spaces.
+
+## Reporting and Enforcement
+
+Report abusive, harassing, or otherwise unacceptable behavior privately to
+[github@beforesemicolon.com](mailto:github@beforesemicolon.com). Include relevant
+links or screenshots and enough context to investigate the report. Do not open a
+public issue for a sensitive conduct report.
+
+All reports will be reviewed promptly and fairly. Community leaders will respect
+the privacy and security of reporters and will apply corrective action that is
+appropriate to the nature and severity of the violation. Actions may range from
+a private correction or warning to a temporary or permanent ban from project
+spaces.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at the [Contributor Covenant 2.1 page][version].
+
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Thank you for helping improve Markup. Bug reports, documentation fixes, tests,
+and focused feature proposals are welcome.
+
+## Before You Start
+
+-   Search existing issues and pull requests before opening a duplicate.
+-   Use the issue templates and include a minimal reproduction for bugs.
+-   Discuss substantial API or behavior changes in an issue before implementation.
+-   Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+-   Report vulnerabilities through the private process in [SECURITY.md](SECURITY.md).
+
+## Development
+
+Use a Node.js and npm version supported by `package.json` and CI.
+
+```sh
+npm ci
+npm test
+npm run lint
+npm run build
+```
+
+Keep changes focused and add or update tests for behavior changes. Update the
+documentation when public APIs or documented behavior change.
+
+## Pull Requests
+
+1. Create a branch from `main`.
+2. Make a focused change with clear commit messages.
+3. Run the test, lint, and build commands above.
+4. Complete the pull request template and link any related issue.
+5. Address review feedback and keep the branch current with `main`.
+
+Pull requests require review before merge. By contributing, you agree that your
+contribution is licensed under this project's [BSD 3-Clause License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -126,3 +126,10 @@ This library requires no build or parsing. The CDN package is one digit killobyt
     html`<h1>Hello World</h1>`.render(document.getElementById('app'))
 </script>
 ```
+
+## Community
+
+-   [Contributing guidelines](CONTRIBUTING.md)
+-   [Code of Conduct](CODE_OF_CONDUCT.md)
+-   [Security policy](SECURITY.md)
+-   [BSD 3-Clause License](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the latest published release. Older releases
+may be asked to upgrade before receiving a fix.
+
+| Version        | Supported |
+| -------------- | --------- |
+| Latest release | Yes       |
+| Older releases | No        |
+
+## Reporting a Vulnerability
+
+Do not open a public issue for a suspected vulnerability.
+
+Use [GitHub private vulnerability reporting](https://github.com/beforesemicolon/markup/security/advisories/new).
+If that form is unavailable, email
+[github@beforesemicolon.com](mailto:github@beforesemicolon.com).
+
+Please include:
+
+-   The affected package version and environment
+-   A description of the impact and affected component
+-   Reproduction steps or a minimal proof of concept
+-   Any known mitigations or workarounds
+-   Whether the issue has been disclosed elsewhere
+
+You should receive an acknowledgment within five business days. We will keep you
+informed as the report is validated and remediated, and will coordinate public
+disclosure when appropriate.


### PR DESCRIPTION
## Summary

- add a top-level Code of Conduct, contribution guide, and security policy
- add CODEOWNERS plus structured issue and pull request templates
- link the community documents from the README

## Validation

- npm run lint
- npm test -- --runInBand
- npm audit --omit=dev