### PR TITLE
Harden state and effect reactivity

### DIFF
--- a/src/state.api.spec.ts
+++ b/src/state.api.spec.ts
@@ -1,0 +1,80 @@
+import '../test.common.ts'
+import { state } from './state.ts'
+
+describe('state api', () => {
+    it('should return the updated value from the setter', () => {
+        const [count, setCount] = state(0)
+
+        const updatedValue: number = setCount(1)
+
+        expect(updatedValue).toBe(1)
+        expect(count()).toBe(1)
+    })
+
+    it('should apply updater functions synchronously in sequence', () => {
+        const [count, setCount] = state(1)
+
+        expect(setCount((value) => value + 1)).toBe(2)
+        expect(setCount((value) => value * 3)).toBe(6)
+        expect(count()).toBe(6)
+    })
+
+    it('should use Object.is semantics when deciding whether a value changed', () => {
+        const onUpdate = jest.fn()
+        const [value, setValue] = state<number>(NaN, onUpdate)
+
+        setValue(NaN)
+        jest.advanceTimersToNextTimer()
+
+        expect(onUpdate).not.toHaveBeenCalled()
+        expect(Number.isNaN(value())).toBe(true)
+
+        setValue(0)
+        jest.advanceTimersToNextTimer()
+        onUpdate.mockClear()
+
+        setValue(-0)
+        jest.advanceTimersToNextTimer()
+
+        expect(onUpdate).toHaveBeenCalledTimes(1)
+        expect(Object.is(value(), -0)).toBe(true)
+    })
+
+    it('should not call an explicit subscriber if it unsubscribes before the flush', () => {
+        const onUpdate = jest.fn()
+        const [, setCount, unsubscribe] = state(0, onUpdate)
+
+        setCount(1)
+        unsubscribe()
+        jest.advanceTimersToNextTimer()
+
+        expect(onUpdate).not.toHaveBeenCalled()
+    })
+
+    it('should support function values by returning them from an updater', () => {
+        const initialHandler = jest.fn()
+        const nextHandler = jest.fn()
+        const [handler, setHandler] = state<() => void>(initialHandler)
+
+        const updatedHandler = setHandler(() => nextHandler)
+
+        expect(updatedHandler).toBe(nextHandler)
+        expect(handler()).toBe(nextHandler)
+
+        handler()()
+        expect(nextHandler).toHaveBeenCalledTimes(1)
+        expect(initialHandler).not.toHaveBeenCalled()
+    })
+
+    it('should not notify when a function-valued state resolves to the same function', () => {
+        const handler = jest.fn()
+        const onUpdate = jest.fn()
+        const [getHandler, setHandler] = state<() => void>(handler, onUpdate)
+
+        setHandler(() => handler)
+        jest.advanceTimersToNextTimer()
+
+        expect(getHandler()).toBe(handler)
+        expect(onUpdate).not.toHaveBeenCalled()
+    })
+})

--- a/src/state.spec.ts
+++ b/src/state.spec.ts
@@ -64,6 +64,25 @@ describe('effect', () => {
         
         expect(valueSpy).toBeCalledTimes(0)
     })
+
+    it('should batch multiple dependency updates into one execution', () => {
+        const valueSpy = jest.fn()
+        const [count, setCount]= state(0);
+        const [limit, setLimit]= state(0);
+        const [offset, setOffset]= state(0);
+
+        effect(() => {
+            valueSpy(count(), limit(), offset())
+        })
+
+        setCount(1)
+        setLimit(2)
+        setOffset(3)
+        jest.advanceTimersToNextTimer()
+
+        expect(valueSpy).toBeCalledTimes(2)
+        expect(valueSpy).toHaveBeenLastCalledWith(1, 2, 3)
+    })
     
     it('should work correctly when nested for different values', () => {
         const valueSpy1 = jest.fn()
@@ -130,14 +149,14 @@ describe('effect', () => {
 
         expect(valueSpy1).toBeCalledTimes(2)
         expect(valueSpy1).toBeCalledWith(1)
-        expect(valueSpy2).toBeCalledTimes(4)
-        expect(valueSpy2).toBeCalledWith(0)
+        expect(valueSpy2).toBeCalledTimes(2)
+        expect(valueSpy2).toBeCalledWith(1)
 
         valueSpy1.mockClear()
         valueSpy2.mockClear()
         unsub()
 
-        setCount(1)
+        setCount(2)
         jest.advanceTimersToNextTimer()
 
         expect(valueSpy1).toBeCalledTimes(0)
@@ -190,5 +209,67 @@ describe('effect', () => {
         expect(valueSpy).toHaveBeenCalledTimes(0)
         expect(total()).toBe(20)
         expect(count()).toBe(2)
+    })
+
+    it('should unsubscribe from dependencies that are no longer read', () => {
+        const valueSpy = jest.fn()
+        const [enabled, setEnabled] = state(true)
+        const [count, setCount] = state(0)
+
+        effect(() => {
+            valueSpy(enabled() ? count() : 'disabled')
+        })
+
+        expect(valueSpy).toHaveBeenLastCalledWith(0)
+
+        setEnabled(false)
+        jest.advanceTimersToNextTimer()
+
+        expect(valueSpy).toHaveBeenLastCalledWith('disabled')
+
+        valueSpy.mockClear()
+        setCount(1)
+        jest.advanceTimersToNextTimer()
+
+        expect(valueSpy).not.toHaveBeenCalled()
+    })
+
+    it('should discover dependencies again when conditional branches change', () => {
+        const valueSpy = jest.fn()
+        const [useCount, setUseCount] = state(true)
+        const [count, setCount] = state(0)
+        const [total, setTotal] = state(10)
+
+        effect(() => {
+            valueSpy(useCount() ? count() : total())
+        })
+
+        setUseCount(false)
+        jest.advanceTimersToNextTimer()
+
+        valueSpy.mockClear()
+        setCount(1)
+        jest.advanceTimersToNextTimer()
+        expect(valueSpy).not.toHaveBeenCalled()
+
+        setTotal(20)
+        jest.advanceTimersToNextTimer()
+        expect(valueSpy).toHaveBeenCalledTimes(1)
+        expect(valueSpy).toHaveBeenLastCalledWith(20)
+
+        valueSpy.mockClear()
+        setUseCount(true)
+        jest.advanceTimersToNextTimer()
+        expect(valueSpy).toHaveBeenLastCalledWith(1)
+
+        valueSpy.mockClear()
+        setTotal(30)
+        jest.advanceTimersToNextTimer()
+        expect(valueSpy).not.toHaveBeenCalled()
+
+        setCount(2)
+        jest.advanceTimersToNextTimer()
+        expect(valueSpy).toHaveBeenCalledTimes(1)
+        expect(valueSpy).toHaveBeenLastCalledWith(2)
     })
 })

--- a/src/state.ts
+++ b/src/state.ts
@@ -98,7 +98,7 @@ export const state = <T>(
                     ? (newVal as (val: T) => T)(value)
                     : newVal
 
-            if (updatedValue !== value) {
+            if (!Object.is(updatedValue, value)) {
                 value = updatedValue
                 if (!subs.size) {
                     return updatedValue

--- a/src/state.ts
+++ b/src/state.ts
@@ -26,14 +26,26 @@ const scheduledExecutions = new DoubleLinkedList<
 let flushPending = false
 
 const flushScheduledExecutions = () => {
-    const visited = new DoubleLinkedList<StateSubscriber>()
+    const queued = new DoubleLinkedList<StateSubscriber>()
 
     for (const subs of scheduledExecutions) {
         for (const sub of subs) {
-            if (!visited.has(sub)) {
-                visited.push(sub)
-                sub()
+            queued.push(sub)
+        }
+    }
+
+    for (const sub of queued) {
+        let isStillSubscribed = false
+
+        for (const subs of scheduledExecutions) {
+            if (subs.has(sub)) {
+                isStillSubscribed = true
+                break
             }
+        }
+
+        if (isStillSubscribed) {
+            sub()
         }
     }
 
@@ -107,6 +119,17 @@ export const effect = <T>(sub: EffectSubscriber<T>) => {
         let isRunning = false
         let pendingReRun = false
 
+        const clearDependencies = () => {
+            for (const child of res.children) {
+                child.clear()
+            }
+            for (const unsub of res.unsubs) {
+                unsub()
+            }
+            res.children.clear()
+            res.unsubs.clear()
+        }
+
         const run = () => {
             if (isRunning) {
                 pendingReRun = true
@@ -114,6 +137,7 @@ export const effect = <T>(sub: EffectSubscriber<T>) => {
             }
 
             isRunning = true
+            clearDependencies()
 
             const parent = currentResolvers.tail
 
@@ -143,14 +167,7 @@ export const effect = <T>(sub: EffectSubscriber<T>) => {
             unsubs: new DoubleLinkedList(),
             children: new DoubleLinkedList(),
             clear() {
-                for (const child of this.children) {
-                    child.clear()
-                }
-                for (const unsub of this.unsubs) {
-                    unsub()
-                }
-                this.children.clear()
-                this.unsubs.clear()
+                clearDependencies()
                 value = undefined
             },
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface DynamicValue<T = unknown, D = unknown> {
 }
 
 export type StateGetter<T> = () => T
-export type StateSetter<T> = (newVal: T | ((val: T) => T)) => void
+export type StateSetter<T> = (newVal: T | ((val: T) => T)) => T
 export type StateSubscriber = () => void
 export type StateUnSubscriber = () => void
 


### PR DESCRIPTION
## What changed

- Recollect effect dependencies on every execution instead of accumulating subscriptions for the lifetime of the effect.
- Dispose nested effects before recreating them during a parent effect rerun.
- Keep the scheduler deduplicated while preventing subscribers removed during the same flush from running.
- Preserve conditional dependency discovery when an effect switches between state branches.
- Use `Object.is` semantics for state equality checks.
- Align `StateSetter<T>` with runtime behavior by returning the updated `T` value.
- Lock down function-valued state behavior: function arguments remain updater callbacks, while a function value can be stored by returning it from an updater.

## Why

Effects already discovered dependencies automatically, but stale dependencies remained subscribed after subsequent executions stopped reading them. Nested effects also accumulated across reruns, causing duplicate executions.

The state primitive also had a few contract gaps: `NaN` was treated as changed when set to `NaN`, `0` and `-0` were treated as equal, and the public setter type declared `void` even though the runtime returns the updated value.

## Tests

Added regression coverage for:

- batching multiple state updates into one effect execution
- unsubscribing dependencies that are no longer read
- rediscovering dependencies when conditional branches change
- nested effects sharing the same state without duplicate executions
- cleanup after effect teardown
- setter return values
- synchronous updater sequencing
- `Object.is` equality behavior for `NaN`, `0`, and `-0`
- unsubscribe-before-flush behavior
- storing and retaining function-valued state

One existing nested-effect assertion was corrected from four inner executions to two because the previous expectation encoded duplicate subscriptions rather than intended behavior.

## Validation

The core state/effect behavior was exercised in a standalone Node harness covering conditional unsubscribe/re-subscribe, nested effects, and batching. Repository CI runs the full Jest/build suite for this PR on Node 22 and Node 24.