### PR TITLE
Fix template cache identity

### DIFF
--- a/src/html.template-cache.spec.ts
+++ b/src/html.template-cache.spec.ts
@@ -1,0 +1,37 @@
+import '../test.common.ts'
+import { html } from './html.ts'
+
+describe('html template cache', () => {
+    it('should keep distinct tagged template literal shapes separate', () => {
+        const renderFirst = (value: string) =>
+            html`<div data-value="a,b${value}c"></div>`
+        const renderSecond = (value: string) =>
+            html`<div data-value="a${value}b,c"></div>`
+
+        expect(renderFirst('X').toString()).toBe(
+            '<div data-value="a,bXc"></div>'
+        )
+        expect(renderSecond('X').toString()).toBe(
+            '<div data-value="aXb,c"></div>'
+        )
+    })
+
+    it('should not reuse values from the first attribute-object invocation', () => {
+        const view = (attrs: Record<string, unknown>) => html`<div ${attrs}></div>`
+
+        expect(view({ title: 'one', dataId: 'first' }).toString()).toBe(
+            '<div title="one" data-id="first"></div>'
+        )
+        expect(view({ title: 'two', dataId: 'second' }).toString()).toBe(
+            '<div title="two" data-id="second"></div>'
+        )
+    })
+
+    it('should not cache manually-created string arrays by content identity', () => {
+        const first = html(['<span>', '</span>'], 'one')
+        const second = html(['<strong>', '</strong>'], 'two')
+
+        expect(first.toString()).toBe('<span>one</span>')
+        expect(second.toString()).toBe('<strong>two</strong>')
+    })
+})

--- a/src/html.ts
+++ b/src/html.ts
@@ -24,7 +24,7 @@ import { isObjectLiteral } from './utils/is-object-literal.ts'
 const isKnownHTMLEventName = (name: string) =>
     typeof (document ?? {})[name as keyof Document] !== 'undefined'
 
-const templateRegistry: Record<string, Template> = {}
+const templateRegistry = new WeakMap<TemplateStringsArray, Template>()
 
 interface AttributeSlot {
     type: 'attribute'
@@ -86,15 +86,23 @@ const handleAppendChild = (
     parentNode.appendChild(n)
 }
 
+const isTemplateStringsArray = (
+    parts: TemplateStringsArray | string[]
+): parts is TemplateStringsArray =>
+    Object.prototype.hasOwnProperty.call(parts, 'raw')
+
 function createTemplate(
     parts: TemplateStringsArray | string[],
     values: unknown[]
 ) {
-    const tempId = parts.toString()
+    const cacheableParts = isTemplateStringsArray(parts) ? parts : null
+    const cached = cacheableParts ? templateRegistry.get(cacheableParts) : null
 
-    if (templateRegistry[tempId]) {
-        return templateRegistry[tempId]
+    if (cached) {
+        return cached
     }
+
+    let canCache = Boolean(cacheableParts)
 
     // Build templateString efficiently
     let templateString = parts[0]
@@ -149,6 +157,11 @@ function createTemplate(
                     if (dynamicValue) {
                         const idx = Number(dynamicValue[1])
                         const attrs = values[idx]
+
+                        // Attribute-object shape is value-dependent today, so do not
+                        // cache the compiled template until object spreads become
+                        // value-independent slots.
+                        canCache = false
 
                         if (isObjectLiteral(attrs)) {
                             let markSlot = false
@@ -217,15 +230,18 @@ function createTemplate(
         },
     })
 
-    // Always clone the parsed template in #init, do not cache a pre-cloned fragment
-    templateRegistry[tempId] = {
+    const compiledTemplate = {
         // @ts-expect-error all elements have __self__
         template: temp.__self__ as DocumentFragment,
         slots,
         nodeRefs,
     }
 
-    return templateRegistry[tempId]
+    if (canCache && cacheableParts) {
+        templateRegistry.set(cacheableParts, compiledTemplate)
+    }
+
+    return compiledTemplate
 }
 
 function handleElementEventListener(


### PR DESCRIPTION
## What changed

- Cache compiled tagged templates by `TemplateStringsArray` identity with a `WeakMap` instead of `parts.toString()`.
- Skip caching manually-created string arrays.
- Skip caching attribute-object templates for now because their compiled shape still depends on the invocation values.

## Why

`parts.toString()` can collide for distinct template literal shapes. Attribute-object templates can also capture the first invocation's primitive values in the cached DOM and incorrectly reuse them for later invocations.

## Tests

Added regression coverage for:

- distinct tagged template shapes whose `parts.toString()` values collide
- repeated calls to the same attribute-object template with different values
- manually-created string arrays

This PR intentionally does not redesign attribute-object slots; it fixes correctness with the smallest behavior-preserving change.