### PR TITLE
Unify content normalization

### DIFF
--- a/src/ReactiveNode.ts
+++ b/src/ReactiveNode.ts
@@ -4,6 +4,7 @@ import { syncNodes } from './utils/sync-nodes.ts'
 import { EffectUnSubscriber } from './types.ts'
 import { renderContent } from './utils/render-content.ts'
 import { DoubleLinkedList } from './DoubleLinkedList.ts'
+import { normalizeContent } from './utils/normalize-content.ts'
 
 export class ReactiveNode {
     #result = new DoubleLinkedList<Node | HtmlTemplate>()
@@ -25,12 +26,12 @@ export class ReactiveNode {
 
         for (const item of this.#result) {
             if (item instanceof HtmlTemplate) {
-                const templateRefs = item.refs // item.refs is Record<string, Array<Element>>
+                const templateRefs = item.refs
                 for (const key in templateRefs) {
                     if (
                         Object.prototype.hasOwnProperty.call(templateRefs, key)
                     ) {
-                        collectedRefs[key] = templateRefs[key] // Assign properties directly
+                        collectedRefs[key] = templateRefs[key]
                     }
                 }
             }
@@ -57,7 +58,7 @@ export class ReactiveNode {
                 if (init) {
                     this.#result = syncNodes(
                         this.#result,
-                        Array.isArray(res) ? res : [res],
+                        normalizeContent(res),
                         this.#anchor,
                         template
                     )

--- a/src/utils/get-node-or-template.ts
+++ b/src/utils/get-node-or-template.ts
@@ -1,6 +1,0 @@
-import { HtmlTemplate } from '../html.ts'
-
-export function getNodeOrTemplate(value: unknown) {
-    if (value instanceof Node || value instanceof HtmlTemplate) return value
-    return document.createTextNode(String(value))
-}

--- a/src/utils/normalize-content.spec.ts
+++ b/src/utils/normalize-content.spec.ts
@@ -1,0 +1,28 @@
+import { html, HtmlTemplate } from '../html.ts'
+import { normalizeContent } from './normalize-content.ts'
+
+describe('normalizeContent', () => {
+    it('should preserve nodes and templates', () => {
+        const node = document.createElement('span')
+        const template = html`<p>sample</p>`
+
+        expect(normalizeContent([node, template])).toEqual([node, template])
+    })
+
+    it('should convert primitive values to text nodes', () => {
+        const [text] = normalizeContent(12)
+
+        expect(text).toBeInstanceOf(Text)
+        expect((text as Text).nodeValue).toBe('12')
+    })
+
+    it('should flatten one array level only', () => {
+        const template = html`<p>sample</p>`
+        const result = normalizeContent(['a', template, ['b', 'c']])
+
+        expect(result).toHaveLength(3)
+        expect((result[0] as Text).nodeValue).toBe('a')
+        expect(result[1]).toBeInstanceOf(HtmlTemplate)
+        expect((result[2] as Text).nodeValue).toBe('b,c')
+    })
+})

--- a/src/utils/normalize-content.ts
+++ b/src/utils/normalize-content.ts
@@ -1,0 +1,21 @@
+import { HtmlTemplate } from '../html.ts'
+
+export type NormalizedContent = Node | HtmlTemplate
+
+const normalizeValue = (value: unknown): NormalizedContent => {
+    if (value instanceof Node || value instanceof HtmlTemplate) {
+        return value
+    }
+
+    return document.createTextNode(String(value))
+}
+
+/**
+ * Normalizes renderable content into the representation used by both initial
+ * rendering and reactive updates. Arrays are flattened by one level only;
+ * nested arrays are rendered as text to preserve existing behavior.
+ */
+export const normalizeContent = (content: unknown): NormalizedContent[] =>
+    Array.isArray(content)
+        ? content.map((item) => normalizeValue(item))
+        : [normalizeValue(content)]

--- a/src/utils/render-content.ts
+++ b/src/utils/render-content.ts
@@ -1,41 +1,18 @@
 import { HtmlTemplate } from '../html.ts'
-
-function createAndRenderTextNode(
-    value: unknown,
-    parentNode: HTMLElement | DocumentFragment | Element
-) {
-    const node = document.createTextNode(String(value))
-    parentNode.appendChild(node)
-    return node
-}
+import { normalizeContent } from './normalize-content.ts'
 
 export const renderContent = (
     content: unknown,
     parentNode: HTMLElement | DocumentFragment,
     cb: (item: HtmlTemplate | Node) => void
 ) => {
-    if (Array.isArray(content)) {
-        for (const item of content) {
-            // ensure only one level of the Array is rendered
-            if (Array.isArray(item)) {
-                cb(createAndRenderTextNode(item, parentNode))
-            } else {
-                renderContent(item, parentNode, cb)
-            }
+    for (const item of normalizeContent(content)) {
+        if (item instanceof HtmlTemplate) {
+            item.render(parentNode)
+        } else {
+            parentNode.appendChild(item)
         }
 
-        return
+        cb(item)
     }
-
-    if (content instanceof HtmlTemplate) {
-        content.render(parentNode)
-        return cb(content)
-    }
-
-    if (content instanceof Node) {
-        parentNode.appendChild(content)
-        return cb(content)
-    }
-
-    cb(createAndRenderTextNode(content, parentNode))
 }

--- a/src/utils/sync-nodes.ts
+++ b/src/utils/sync-nodes.ts
@@ -1,6 +1,5 @@
 import { HtmlTemplate } from '../html.ts'
 import { insertNodeAfter } from './insert-node-after.ts'
-import { getNodeOrTemplate } from '../utils/get-node-or-template.ts'
 import { DoubleLinkedList } from '../DoubleLinkedList.ts'
 
 /**
@@ -10,7 +9,7 @@ import { DoubleLinkedList } from '../DoubleLinkedList.ts'
  * which means querying it would be inaccurate
  *
  * @param currentChildNodes - list of parent node child nodes
- * @param newChildNodesInput - list of nodes of how the parent node child nodes should become
+ * @param newChildNodesInput - normalized list of nodes of how the parent node child nodes should become
  * @param anchorNode - the node to insert new nodes after
  * @param template - the parent HtmlTemplate instance
  */
@@ -28,20 +27,16 @@ export const syncNodes = (
         return currentChildNodes
     }
 
-    // Process newChildNodes once and create a Set for efficient lookups
-    const newChildNodesArray = newChildNodesInput.map((n) =>
-        getNodeOrTemplate(n)
-    )
-    const newChildNodesSet = new Set(newChildNodesArray)
+    const newChildNodesSet = new Set(newChildNodesInput)
 
     if (currentChildNodes.size) {
         let prevN: Node | HtmlTemplate = anchorNode
         let idx = 0
         let currentNode: Node | HtmlTemplate | null = currentChildNodes.head
 
-        while (idx < newChildNodesArray.length || currentNode) {
+        while (idx < newChildNodesInput.length || currentNode) {
             const newNode =
-                idx < newChildNodesArray.length ? newChildNodesArray[idx] : null
+                idx < newChildNodesInput.length ? newChildNodesInput[idx] : null
             const newAdded =
                 newNode &&
                 !currentChildNodes.has(newNode) &&
@@ -113,9 +108,7 @@ export const syncNodes = (
     } else {
         const frag = document.createDocumentFragment()
 
-        for (const newNode of newChildNodesArray) {
-            const node = getNodeOrTemplate(newNode)
-
+        for (const node of newChildNodesInput) {
             if (node instanceof HtmlTemplate) {
                 node.render(frag)
                 node.__PARENT__ = template


### PR DESCRIPTION
## What changed

- Add one shared content normalization path for initial rendering and reactive updates.
- Preserve the existing one-level array behavior: top-level arrays render item-by-item while nested arrays become text.
- Make `ReactiveNode` normalize update results before reconciliation.
- Remove duplicate conversion work from `syncNodes` and delete the now-unused `get-node-or-template` utility.

## Why

Initial rendering previously used `renderContent`, while updates used a separate `getNodeOrTemplate` conversion path inside `syncNodes`. Keeping two normalization models increases implementation complexity and risks semantic drift.

## Tests

Added focused normalization tests for nodes/templates, primitive values, and nested arrays. The existing `html`, `ReactiveNode`, and `syncNodes` suites remain the primary behavior contract.